### PR TITLE
dx: add format:check script for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
       - name: svelte-check
         run: npx svelte-check --tsconfig ./tsconfig.json --threshold warning
 
+      - name: Check formatting
+        run: npm run format:check
+        working-directory: dashboard
+
       - name: build
         run: npm run build
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.5",


### PR DESCRIPTION
## What
Adds a new prettier npm command to check formatting and its CI step on Github actions

## Why
Closes #4

## Scope & invariants

- [x] I've read [ARCHITECTURE.md → Architecture Invariants](../ARCHITECTURE.md#architecture-invariants)
      and this PR does not violate any of them.
- [x] This PR is focused on one change. Unrelated refactors are split out.

## Verification

- [x] `make ci` passes locally
- [ ] New code has tests matching [ARCHITECTURE.md → Testing Philosophy](../ARCHITECTURE.md#testing-philosophy)
- [ ] For UI changes: tested in a browser against a running `docker compose up -d`
